### PR TITLE
Distinguish invalid credentials from generic connectivity failures

### DIFF
--- a/eldom/client.py
+++ b/eldom/client.py
@@ -9,6 +9,10 @@ from .naturela_boiler import NaturelaBoilerClient
 from .smart_boiler import SmartBoilerClient
 
 
+class InvalidCredentialsError(Exception):
+    """Raised when the API rejects the session as unauthorized (401/403)."""
+
+
 class Client:
     """
     Eldom main API client for the `myeldom.com` APIs.
@@ -101,9 +105,18 @@ class Client:
         Check whether the connection is established.
 
         :return: Boolean showing if the client is connected.
+        :raises InvalidCredentialsError: If the session was rejected as unauthorized
+            (401/403) — distinct from a generic connectivity failure, since it means
+            retrying won't help without new credentials.
         """
         try:
             await self.get_devices()
             return True
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403):
+                raise InvalidCredentialsError(
+                    "Invalid email or password"
+                ) from err
+            return False
         except Exception:
             return False

--- a/ioteldom/client.py
+++ b/ioteldom/client.py
@@ -8,6 +8,10 @@ from .models import Device, User
 from .token_provider import TokenProvider
 
 
+class InvalidCredentialsError(Exception):
+    """Raised when the API rejects the session as unauthorized (401/403)."""
+
+
 class Client:
     """
     Eldom main API client for the `iot.myeldom.com` APIs.
@@ -101,9 +105,18 @@ class Client:
         Check whether the connection is established.
 
         :return: Boolean showing if the client is connected.
+        :raises InvalidCredentialsError: If the session was rejected as unauthorized
+            (401/403) — distinct from a generic connectivity failure, since it means
+            retrying won't help without new credentials.
         """
         try:
             await self.get_devices()
             return True
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403):
+                raise InvalidCredentialsError(
+                    "Invalid email or password"
+                ) from err
+            return False
         except Exception:
             return False


### PR DESCRIPTION
## Summary

- `is_connected()` in both `eldom/client.py` and `ioteldom/client.py` previously collapsed every exception from `get_devices()` into a bare `False` — no way to tell "wrong password" from "network blip" or "server error"
- Now a 401/403 response raises `InvalidCredentialsError` specifically; everything else still returns `False`, unchanged

## Why

Related to qbaware/homeassistant-eldom#28. Home Assistant's `ConfigEntryAuthFailed` (prompts reauth) vs `ConfigEntryNotReady` (silently retries) needs this distinction to work — right now a user with a typo'd password just gets retried forever instead of a clean reauth prompt.

## Test plan

- [x] Verified with mocked `get_devices()` responses: 401 → `InvalidCredentialsError`, 500 → `False`, generic exception → `False`, success → `True`
- [ ] homeassistant-eldom side (propagating this into `ConfigEntryAuthFailed`) is a separate follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)